### PR TITLE
fix: android16 beta2 crashed: signal 11 (SIGSEGV), code 1 (SEGV_MAPER…

### DIFF
--- a/library/src/main/java/org/lsposed/hiddenapibypass/HiddenApiBypass.java
+++ b/library/src/main/java/org/lsposed/hiddenapibypass/HiddenApiBypass.java
@@ -323,6 +323,12 @@ public final class HiddenApiBypass {
         }
         long fields = unsafe.getLong(clazz, sFieldOffset);
         if (fields == 0) return List.of();
+        //Fix: Android16 Beta2 crashed( signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x0000000100000401).
+        if ((fields & 0x7) != 0) {
+            Log.w(TAG, "invalid offset addr:" + Long.toHexString(fields));
+            return List.of();
+        }
+
         int numFields = unsafe.getInt(fields);
         if (BuildConfig.DEBUG) Log.d(TAG, clazz + " has " + numFields + " fields");
         List<Field> list = new ArrayList<>(numFields);


### PR DESCRIPTION
Crash when getting EGL_INSTANCE private static variable of javax.microedition.khronos.egl.EGLContext, executed on Android 16 beta2:
```
 #00 pc 00000000002ce864 /system/framework/arm64/boot.oat (art_jni_trampoline+4) (BuildId: 5ba40e8c479488e66f04857a2f88b909fab90674)
  #01 pc 00000000002f5f94 /apex/com.android.art/lib64/libart.so (art_quick_invoke_stub+612) (BuildId: 7be5cede6cb0201979cdd310947c16b3)
  #02 pc 0000000000745f40 /apex/com.android.art/lib64/libart.so (bool art::interpreter::DoCall<false>(art::ArtMethod*, art::Thread*, art:. ShadowFrame&, art::Instruction const*, unsigned short, bool, art::JValue*)+2068) (BuildId: 7be5cede6cb0201979cdd310947c16b3)
#03 pc 0000000000579db8 /apex/com.android.art/lib64/libart.so (void art::interpreter::ExecuteSwitchImplCpp<false>(art::interpreter:. SwitchImplContext*)+10964) (BuildId: 7be5cede6cb0201979cdd310947c16b3)
 #04 pc 00000000002ad408 /apex/com.android.art/lib64/libart.so (ExecuteSwitchImplAsm+8) (BuildId: 7be5cede6cb0201979cdd310947c16b3)
```